### PR TITLE
Update TSC.md to remove Taylor

### DIFF
--- a/TSC.md
+++ b/TSC.md
@@ -2,7 +2,6 @@
 
 | Name             | GitHub ID                                   | Company Name                            |
 | ---------------- | ------------------------------------------- | --------------------------------------- |
-| Taylor Carpenter | [taylor](https://github.com/taylor)         | [Vulk](https://www.vulk.coop/)          |
 | Richard Lopez    | [rich-l](https://github.com/rich-l)         | [F5](https://www.f5.com/)               |
 | Martin Matyáš    | [martin-mat](https://github.com/martin-mat) | [Tietoevry](https://www.tietoevry.com/) |
 | Cedric Ollivier  | [collivier](https://github.com/collivier)   | [Orange](https://www.orange.com/)       |


### PR DESCRIPTION
Good day, folks.  I am submitting a request to be officially removed from the CNTI TSC. 

It has been a privilege to work with my fellow TSC members. Thank you for all your efforts in promoting community-driven best practices including the functional adoption and usage of related testing practices.   

Thanks especially to @collivier and @Smitholi67 who were early supporters and contributors.  Cedric took the [Vulk Coop's](https://vulk.coop/) testsuite (developed for CNCF) and applied it to Orange's real-world test cases and the [LFE Sylva project](https://gitlab.com/sylva-projects/sylva).  Olivier was one of the first Vendors and LFN members who supported cloud native adoption and promoted it across organizations. 

@rich-l I appreciate that you have been outspoken again and again when others have been quiet, pushing against the status quo to make things better for the community is important.

Thank you @martin-mat for picking up and continuing the maintenance of the testsuite within LFN and contributing to the ongoing success of a cloud native telecom certification.

Cheers,

Taylor