### PR TITLE
Update TSC.md

### DIFF
--- a/TSC.md
+++ b/TSC.md
@@ -5,4 +5,3 @@
 | Richard Lopez    | [rich-l](https://github.com/rich-l)         | [F5](https://www.f5.com/)               |
 | Martin Matyáš    | [martin-mat](https://github.com/martin-mat) | [Tietoevry](https://www.tietoevry.com/) |
 | Cedric Ollivier  | [collivier](https://github.com/collivier)   | [Orange](https://www.orange.com/)       |
-| Olivier Smith    | [smitholi67](https://github.com/smitholi67) | [Matrixx](https://www.matrixx.com/)     |


### PR DESCRIPTION
Removing Olivier Smith as Co-Chair as I will no longer be part of CNTi after end of March 2026.  It has a been a pleasure working with the community.  Thanks!